### PR TITLE
Added error handling to decode() to prevent nil pointer reference

### DIFF
--- a/psd.go
+++ b/psd.go
@@ -285,7 +285,10 @@ func Decode(r io.Reader, o *DecodeOptions) (psd *PSD, read int, err error) {
 
 func decode(r io.Reader) (image.Image, error) {
 	psd, _, err := Decode(r, &DecodeOptions{SkipLayerImage: true})
-	return psd.Picker, err
+	if err != nil {
+		return nil, err
+	}
+	return psd.Picker, nil
 }
 
 func decodeConfig(r io.Reader) (image.Config, error) {


### PR DESCRIPTION
if the Decode() method returns an error, the psd.Picker value will be a nil pointer and will panic. This fix prevents the panic occuring and allows the error to be returned correctly.