### PR TITLE
Recover from panic in decodePackBits

### DIFF
--- a/compress_other.go
+++ b/compress_other.go
@@ -3,10 +3,17 @@
 package psd
 
 import (
+	"fmt"
 	"io"
 	"runtime"
 	"sync"
 )
+
+func recoverFromPanic(errorChan chan<- error) {
+	if r := recover(); r != nil {
+		errorChan <-fmt.Errorf("psd: decodePackBitsPerLine failed with %v", r)
+	}
+}
 
 func decodePackBits(dest []byte, r io.Reader, width int, lines int, large bool) (read int, err error) {
 	buf := make([]byte, lines*(get4or8(large)>>1))
@@ -57,19 +64,33 @@ func decodePackBits(dest []byte, r io.Reader, width int, lines int, large bool) 
 	wg.Add(n)
 	step := lines / n
 	ofs = 0
+	errorChan := make(chan error)
+	wgDoneChan := make(chan bool)
+	go func() {
+		wg.Wait()
+		close(wgDoneChan)
+	}()
 	for i := 1; i < n; i++ {
 		go func(dest []byte, buf []byte, lens []int) {
 			defer wg.Done()
+			defer recoverFromPanic(errorChan)
 			decodePackBitsPerLine(dest, buf, lens)
 		}(dest[ofs*width:(ofs+step)*width], buf[offsets[ofs]:offsets[ofs+step]], lens[ofs:ofs+step])
 		ofs += step
 	}
 	go func() {
 		defer wg.Done()
+		defer recoverFromPanic(errorChan)
 		decodePackBitsPerLine(dest[ofs*width:], buf[offsets[ofs]:], lens[ofs:])
 	}()
-	wg.Wait()
-	return
+
+	select {
+	case <-wgDoneChan:
+		return
+	case err := <-errorChan:
+		close(errorChan)
+		return 0, err
+	}
 }
 
 func decodePackBitsPerLine(dest []byte, buf []byte, lens []int) {


### PR DESCRIPTION
## Why
In our file processing system we detected some serious panics, that caused our main process to be terminated:
```go
panic: runtime error: index out of range [88] with length 88
goroutine 813 [running]:
github.com/oov/psd.decodePackBitsPerLine(0xc00a4fb000, 0xce400, 0xce400, 0xc0006e7ade, 0x276, 0x276, 0xc00066f9c0, 0x14a, 0x14a)
	/go/pkg/mod/github.com/oov/psd@v0.0.0-20191015092724-029bc2b05550/compress_other.go:92 +0x288
github.com/oov/psd.decodePackBits.func2(0xc0001fd8e0, 0xc0098f8000, 0xcd1400, 0xcd1400, 0x1338, 0xa00, 0xc0006b2000, 0x35d54, 0x35d54, 0xc000676000, ...)
	/go/pkg/mod/github.com/oov/psd@v0.0.0-20191015092724-029bc2b05550/compress_other.go:69 +0x174
created by github.com/oov/psd.decodePackBits
	/go/pkg/mod/github.com/oov/psd@v0.0.0-20191015092724-029bc2b05550/compress_other.go:67 +0x5de
```
This issue occurred with several different _length_ values, so this not a failure of the single file.
Unfortunately wrapping the psd code in recover is not enough. The panic is thrown by goroutine and in the Go the panic may be recovered only in the goroutine that caused it.
We are unable to reproduce locally this behavior, as we don't have physical access to the particular files.
## How
To fix the issue I have prepared the solution, that would transform panic in goroutines to the regular error.
Sorry, but I'm unable to add test here, as we don't have troublesome files.