### PR TITLE
Correctly discard IO reads during PSD processing.  

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -149,7 +149,7 @@ func readLayerAndMaskInfo(r io.Reader, cfg *Config, o *DecodeOptions) (psd *PSD,
 				reportReaderPosition("    file offset: 0x%08x", r)
 			}
 			// TODO(oov): implement
-			if l, err = io.ReadFull(r, make([]byte, globalLayerMaskInfoLen)); err != nil {
+			if l, err = discard(r, globalLayerMaskInfoLen); err != nil {
 				return nil, read, err
 			}
 			read += l
@@ -556,7 +556,7 @@ func readLayerExtraData(r io.Reader, layer *Layer, cfg *Config, o *DecodeOptions
 			Debug.Println("  layer blending ranges data skipped:", blendingRangesLen)
 		}
 		// TODO(oov): implement
-		if l, err = io.ReadFull(r, make([]byte, blendingRangesLen)); err != nil {
+		if l, err = discard(r, blendingRangesLen); err != nil {
 			return read, err
 		}
 		read += l

--- a/util.go
+++ b/util.go
@@ -2,6 +2,7 @@ package psd
 
 import (
 	"io"
+	"io/ioutil"
 	"math"
 	"unicode/utf16"
 )
@@ -122,7 +123,8 @@ func discard(r io.Reader, skip int) (read int, err error) {
 		}
 		return skip, nil
 	default:
-		return io.ReadFull(r, make([]byte, skip))
+		rd, err := io.CopyN(ioutil.Discard, r, int64(skip))
+		return int(rd), err
 	}
 }
 


### PR DESCRIPTION
This mitigates potential memory leak and out of memory condition.

[why]
PSD utility did not correctly discard reads that were to be discarded.  Was creating buffer that could be large and would not be garbage collected.

[how]
Correctly discard by using io.CopyN and writing to ioutil.Discard

[testing]
See provided test files which demonstrate memory overflow condition.